### PR TITLE
Trim Email of Whitespace

### DIFF
--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -7,6 +7,6 @@ var gravatar = module.exports = {
       var queryData = querystring.stringify(options);
       var query = (queryData && "?" + queryData) || "";
 
-      return baseURL + crypto.createHash('md5').update(email.toLowerCase()).digest('hex') + query;
+      return baseURL + crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex') + query;
     }
 };


### PR DESCRIPTION
The Gravatar documentation states that the email address shall be trimmed: http://en.gravatar.com/site/implement/hash/

Cheers,
Daniel
