### PR TITLE
https://secure.gravatar.com/avatar/ -> https://s.gravatar.com/avatar/

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ Usage
     var unsecureUrl = gravatar.url('emerleite@gmail.com', {s: '100', r: 'x', d: 'retro'}, false);
     //returns http://www.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100&r=x&d=retro
     var secureUrl = gravatar.url('emerleite@gmail.com', {s: '100', r: 'x', d: 'retro'}, true);
-    //returns https://secure.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100&r=x&d=retro
+    //returns https://s.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100&r=x&d=retro
 
 Running tests (3 ways)
 ----------------------

--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -9,7 +9,7 @@ var gravatar = module.exports = {
       if(typeof protocol === 'undefined'){
         baseURL = "//www.gravatar.com/avatar/";
       } else {
-        baseURL = protocol ? "https://secure.gravatar.com/avatar/" : 'http://www.gravatar.com/avatar/';
+        baseURL = protocol ? "https://s.gravatar.com/avatar/" : 'http://www.gravatar.com/avatar/';
       }
 
       var queryData = querystring.stringify(options);

--- a/test/gravatar.test.js
+++ b/test/gravatar.test.js
@@ -5,7 +5,7 @@ var should = require('should')
 describe('gravatar', function() {
   var baseNoProtocolURL = "//www.gravatar.com/avatar/";
   var baseUnsecureURL = "http://www.gravatar.com/avatar/";
-  var baseSecureURL = "https://secure.gravatar.com/avatar/";
+  var baseSecureURL = "https://s.gravatar.com/avatar/";
 
   it('should gererate correct uri given an email', function() {
     gravatar.url('emerleite@gmail.com').should.be.equal(baseNoProtocolURL + "93e9084aa289b7f1f5e4ab6716a56c3b");


### PR DESCRIPTION
According to https://en.gravatar.com/site/check/ `https://s.gravatar.com/avatar/` is their preferred url.

I stumbled over this because recently `https://secure.gravatar.com/avatar/` stopped working for gravatars of people who did not sign up.

This is the url for one of my email addresses for which I did not create a gravatar:
- `https://secure.gravatar.com/avatar/e7f89cafcd451c9e327ae1f329eac865?d=mm` does not work (file not found)
- `https://s.gravatar.com/avatar/e7f89cafcd451c9e327ae1f329eac865?d=mm` works as expected (showing the silhouette icon)

I tested the new url for people who did sign up. The new url shows their gravatar properly.