### PR TITLE
Detect MD5 hashes and not hash them again

### DIFF
--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -1,9 +1,13 @@
 var crypto = require('crypto')
   , querystring = require('querystring');
 
+var MD5_REGEX = /[0-9a-f]{32}/;
+
 var gravatar = module.exports = {
     url: function (email, options, protocol) {
       email = email || 'unspecified';
+      email = email.trim().toLowerCase();
+      var hash = email.match(MD5_REGEX) ? email : crypto.createHash('md5').update(email).digest('hex');
       var baseURL;
 
       if(typeof protocol === 'undefined'){
@@ -15,9 +19,11 @@ var gravatar = module.exports = {
       var queryData = querystring.stringify(options);
       var query = (queryData && "?" + queryData) || "";
 
-      return baseURL + crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex') + query;
+      return baseURL + hash + query;
     },
     profile_url: function (email, options, https) {
+      email = email.trim().toLowerCase();
+      var hash = email.match(MD5_REGEX) ? email : crypto.createHash('md5').update(email).digest('hex');
       var format = options != undefined && options.format != undefined ?  String(options.format) : 'json'
       //delete options.format
       if (options != undefined && options.format != undefined) delete options.format
@@ -25,6 +31,6 @@ var gravatar = module.exports = {
       var queryData = querystring.stringify(options);
       var query = (queryData && "?" + queryData) || "";
 
-      return baseURL + crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex') + '.' + format + query;
+      return baseURL + hash + '.' + format + query;
     }
 };

--- a/test/gravatar.test.js
+++ b/test/gravatar.test.js
@@ -19,6 +19,11 @@ describe('gravatar', function() {
     gravatar.url('emerleite@YAHOO.com.BR').should.be.equal(baseNoProtocolURL + "6c47672b0d58bd6aae4fa70920cb3ee4");
   });
 
+  it('should detect MD5 hashes and not hash them again', function() {
+    gravatar.url('93e9084aa289b7f1f5e4ab6716a56c3b').should.be.equal(baseNoProtocolURL + "93e9084aa289b7f1f5e4ab6716a56c3b");
+    gravatar.url('93E9084AA289B7F1F5E4AB6716A56C3B').should.be.equal(baseNoProtocolURL + "93e9084aa289b7f1f5e4ab6716a56c3b");
+  });
+
   it('should generate uri with user passed parameters', function() {
     var gravatarURL = gravatar.url('emerleite@gmail.com', { s: '200', f: 'y', r: 'g', d: '404'});
     var queryString = url.parse(gravatarURL, true).query;


### PR DESCRIPTION
A simple regex now checks whether the `email` provided is already hashed. 

I need this since my API provides the frontend with a MD5 of the email only (for security reasons), but the frontend needs to do the gravatar URL generation itself (since that is display stuff, not relevant on the API server).