### PR TITLE
Added newline after the url is printed in the cli.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,5 +10,5 @@ if (!email) {
 }
 
 process.stdout.write(
-  gravatar.url(email, {size: '500', default: 'retro'}, true)
+  gravatar.url(email, {size: '500', default: 'retro'}, true) + '\n'
 )


### PR DESCRIPTION
A command line tool should always end its output with a newline.