### PR TITLE
In Readme, be consistent with option types

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ gravatar.url(email, options, protocol);
   The gravatar email
 * options:
   Query string options. Ex: size or s, default or d, rating or r, forcedefault or f.
-  Should be passed as an object. Ex: {s: 200, f: 'y', d: '404'}
+  Should be passed as an object. Ex: {s: '200', f: 'y', d: '404'}
 * protocol
   Define if will use no protocol, http or https gravatar URL. Default is 'undefined', which generates URLs without protocol. True to force https and false to force http.
 


### PR DESCRIPTION
This was the only place in the documentation or code that mentioned non-string options.
For consistency, this is now also a string.