### PR TITLE
New way to specify the protocol in the `options` object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,28 +26,54 @@ Usage
 
 ```javascript
 var gravatar = require('gravatar');
+
+gravatar.url(email);
+gravatar.url(email, options);
 gravatar.url(email, options, protocol);
+
+gravatar.profile_url(email);
+gravatar.profile_url(email, options);
+gravatar.profile_url(email, options, protocol);
 ```
 
 ## Where:
-* email:
+* `email`:
   The gravatar email
-* options:
-  Query string options. Ex: size or s, default or d, rating or r, forcedefault or f.
-  Should be passed as an object. Ex: {s: '200', f: 'y', d: '404'}
-* protocol
+* `options`:
+  Query string options. Ex: `size` or `s`, `default` or `d`, `rating` or `r`, `forcedefault` or `f`.
+  Additional options not passed as a query string:
+  `protocol` (e.g. `"http"` or `"https"`) and `format` (only for `profile_url`, e.g. `"xml"`, `"qr"`,
+  by default it is `"json"`)
+  Should be passed as an object. Ex: `{s: '200', f: 'y', d: '404'}`
+* `protocol`
   Define if will use no protocol, http or https gravatar URL. Default is 'undefined', which generates URLs without protocol. True to force https and false to force http.
+  It can also be set as `protocol` in `options` - see above.
 
 ### Examples
 
 ```javascript
 var gravatar = require('gravatar');
+
 var url = gravatar.url('emerleite@gmail.com', {s: '200', r: 'pg', d: '404'});
 //returns //www.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=200&r=pg&d=404
+
 var unsecureUrl = gravatar.url('emerleite@gmail.com', {s: '100', r: 'x', d: 'retro'}, false);
 //returns http://www.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100&r=x&d=retro
+
 var secureUrl = gravatar.url('emerleite@gmail.com', {s: '100', r: 'x', d: 'retro'}, true);
 //returns https://s.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100&r=x&d=retro
+
+var httpUrl = gravatar.url('emerleite@gmail.com', {protocol: 'http', s: '100'});
+//returns http://www.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100
+
+var httpsUrl = gravatar.url('emerleite@gmail.com', {protocol: 'https', s: '100'});
+//returns https://s.gravatar.com/avatar/93e9084aa289b7f1f5e4ab6716a56c3b?s=100
+
+var profile1 = gravatar.profile_url('emerleite@gmail.com', {protocol: 'https'});
+//returns https://secure.gravatar.com/93e9084aa289b7f1f5e4ab6716a56c3b.json
+
+var profile2 = gravatar.profile_url('emerleite@gmail.com', {protocol: 'http', format:'qr'});
+//returns http://www.gravatar.com/93e9084aa289b7f1f5e4ab6716a56c3b.qr
 ```
 
 CLI Usage

--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -3,6 +3,20 @@ var crypto = require('crypto')
 
 var MD5_REGEX = /[0-9a-f]{32}/;
 
+function params(options) {
+  var params = {}, removing = {protocol:1, format:1};
+  for (key in options) {
+    if (!removing[key]) params[key] = options[key];
+  }
+  return params;
+}
+function proto(options, protocol) {
+  if (!options) return;
+  return options.protocol === "http" ? false
+       : options.protocol === "https" ? true
+       : undefined;
+}
+
 var gravatar = module.exports = {
     url: function (email, options, protocol) {
       email = email || 'unspecified';
@@ -10,13 +24,14 @@ var gravatar = module.exports = {
       var hash = email.match(MD5_REGEX) ? email : crypto.createHash('md5').update(email).digest('hex');
       var baseURL;
 
+      if (options && options.protocol) protocol = proto(options);
       if(typeof protocol === 'undefined'){
         baseURL = "//www.gravatar.com/avatar/";
       } else {
         baseURL = protocol ? "https://s.gravatar.com/avatar/" : 'http://www.gravatar.com/avatar/';
       }
 
-      var queryData = querystring.stringify(options);
+      var queryData = querystring.stringify(params(options));
       var query = (queryData && "?" + queryData) || "";
 
       return baseURL + hash + query;
@@ -25,10 +40,10 @@ var gravatar = module.exports = {
       email = email.trim().toLowerCase();
       var hash = email.match(MD5_REGEX) ? email : crypto.createHash('md5').update(email).digest('hex');
       var format = options != undefined && options.format != undefined ?  String(options.format) : 'json'
-      //delete options.format
-      if (options != undefined && options.format != undefined) delete options.format
+
+      if (options && options.protocol) https = proto(options);
       var baseURL = (https && "https://secure.gravatar.com/") || 'http://www.gravatar.com/';
-      var queryData = querystring.stringify(options);
+      var queryData = querystring.stringify(params(options));
       var query = (queryData && "?" + queryData) || "";
 
       return baseURL + hash + '.' + format + query;

--- a/test/gravatar.test.js
+++ b/test/gravatar.test.js
@@ -56,6 +56,29 @@ describe('gravatar', function() {
     gravatar.profile_url('emerleite@gmail.com', {format:'qr'}, true).should.equal(profileSecureURL + "93e9084aa289b7f1f5e4ab6716a56c3b.qr");
     gravatar.profile_url('emerleite@gmail.com').should.equal(profileURL + "93e9084aa289b7f1f5e4ab6716a56c3b.json");
   });
+
+  it('should force http protocol on gravatar uri generation via options', function() {
+    gravatar.url('emerleite@gmail.com', {protocol: 'http'}).should.be.equal(baseUnsecureURL + "93e9084aa289b7f1f5e4ab6716a56c3b");
+    gravatar.url('emerleite@yahoo.com.br', {protocol: 'http'}).should.be.equal(baseUnsecureURL + "6c47672b0d58bd6aae4fa70920cb3ee4");
+  });
+
+  it('should force https protocol on gravatar uri generation via options', function() {
+    gravatar.url('emerleite@gmail.com', {protocol: 'https'}).should.equal(baseSecureURL + "93e9084aa289b7f1f5e4ab6716a56c3b");
+  });
+
+  it('should generate uri with user passed parameters and protocol in options', function() {
+    var gravatarURL = gravatar.url('emerleite@gmail.com', {protocol: 'https', s: '200', f: 'y', r: 'g', d: '404'});
+    var queryString = url.parse(gravatarURL, true).query;
+    queryString.should.eql({s: '200', f: 'y', r: 'g', d: '404'});
+  });
+
+  it('should generate profile url with protocol in options', function() {
+    gravatar.profile_url('emerleite@gmail.com', {protocol: 'https'}).should.equal(profileSecureURL + "93e9084aa289b7f1f5e4ab6716a56c3b.json");
+    gravatar.profile_url('emerleite@gmail.com', {protocol: 'https', format:'xml'}).should.equal(profileSecureURL + "93e9084aa289b7f1f5e4ab6716a56c3b.xml");
+    gravatar.profile_url('emerleite@gmail.com', {protocol: 'http', format:'qr'}).should.equal(profileURL + "93e9084aa289b7f1f5e4ab6716a56c3b.qr");
+    gravatar.profile_url('emerleite@gmail.com').should.equal(profileURL + "93e9084aa289b7f1f5e4ab6716a56c3b.json");
+  });
+
 });
 
 describe("CLI", function() {


### PR DESCRIPTION
I added a new way to specify the protocol in the `options` object. You can now use:
`gravatar.url('emerleite@gmail.com', {protocol: 'https', s: '100'});`
The previous way still works as well:
`gravatar.url('emerleite@gmail.com', {s: '100'}, true);`
I also added new tests, documentation and examples. I hope it can be merged and put on npm.
If anything needs changing before merging, please let me know and I'll fix it.