### PR TITLE
Fix global variable leak

### DIFF
--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -5,7 +5,7 @@ var MD5_REGEX = /[0-9a-f]{32}/;
 
 function params(options) {
   var params = {}, removing = {protocol:1, format:1};
-  for (key in options) {
+  for (var key in options) {
     if (!removing[key]) params[key] = options[key];
   }
   return params;


### PR DESCRIPTION
The variable `key` was globally defined, causing a key leak.